### PR TITLE
fix: use external API for fetching book metadata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ ipcMain.handle("parseSpreadsheet", (event, data) => {
 
 ipcMain.handle("getBookFromWook", async (event, isbn) => {
   try {
-    const { data } = await axios.get(`https://www.wook.pt/pesquisa/${isbn}`);
+    const { data } = await axios.get(`https://book-api.diogotc.com/wook/info-by-isbn/${isbn}`);
     return data;
   } catch (e) {
     return false;

--- a/src/main.js
+++ b/src/main.js
@@ -63,9 +63,7 @@ const fetchData = async function () {
 
   for (const isbn of Object.keys(content)) {
     const qnt = content[isbn];
-    const data = await window.electronAPI.getBookFromWook(isbn);
-    const dataString = WOOK_REGEX.exec(data || "")?.[1] || "{}";
-    const bookMetadata = JSON.parse(dataString);
+    const bookMetadata = await window.electronAPI.getBookFromWook(isbn);
     const price = bookMetadata.offers && bookMetadata.offers.price;
     if (price) prices[isbn] = price;
     tableBody.insertAdjacentHTML(


### PR DESCRIPTION
Going directly to the website no longer works